### PR TITLE
feat: added translation of `Get Started` documentation page

### DIFF
--- a/app/pages/docs/get-started.mdx
+++ b/app/pages/docs/get-started.mdx
@@ -16,9 +16,9 @@ projets.
 ### Installez Blitz {#install-blitz}
 
 Exécutez `yarn global add blitz` ou
-`npm install -g blitz --legacy-peer-deps` . Notez que l'option legacy-peer-deps est requise car certaines dépendances ne se sont toujours pas adaptées au nouveau comportement imposé par npm.
-depuis qu'npm a entièrement changé le comportement des peer deps et
-certaines dépendances ne se sont toujours pas adaptées)
+`npm install -g blitz --legacy-peer-deps` . Notez que l'option legacy-peer-deps est
+requise car certaines dépendances ne se sont toujours pas adaptées au nouveau comportement
+imposé par npm.
 
 ### Créez une nouvelle application {#create-a-new-app}
 
@@ -75,7 +75,6 @@ ainsi que la lecture et la mise à jour de données depuis votre frontend.
 ### Apprentissage {#learning}
 
 Voici une liste des concepts majeurs de Blitz qui vous serons utiles pour débuter.
-le départ.
 
 - Comment [créer des pages](./pages)
 - Comment [utiliser la navigation par système de fichiers](./routing)


### PR DESCRIPTION
Voici la traduction pour la première page de documentation "Get Started". J'ai vu dans #2 que @Mangiang avait encodé les caractères spéciaux mais je ne suis pas certain que ce soit requis ici puisqu'il s'agit de fichiers MDX.

[Rendu PDF](https://github.com/blitz-js/fr.blitzjs.com/files/7360702/get-started.pdf)
